### PR TITLE
Enable importing from Challonge community subdomains

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -23,32 +23,34 @@ class AncestorForm(forms.Form) :
     fscolor2 = RGBColorField(label="Font Shadow Color", initial="#000000")
 
 class SmashggForm(forms.Form) :
+    startgg_re = r"https://(www\.)?(smash|start)\.gg/(tournament/[^/]+/event/[^/]+)"
+    challonge_re = r"https://([^\.]*)\.?challonge\.com/([^/]+)"
+    tonamel_re = r"https://tonamel\.com/competition/([^/]+)"
+
     event = forms.RegexField(label="External link",
-                             regex = r"https://(www\.)?(smash|start).gg/tournament/[^/]+/event/[^/]+.*|https://([^\.]+\.)?challonge.com/[^/]+.*|https://tonamel.com/competition/[^/]+.*",
+                             regex = "|".join([startgg_re, challonge_re, tonamel_re]),
                              max_length=200)
     def clean(self):
         cleaned_data = super().clean()
         try:
             event = cleaned_data.get("event")
             
-            # start gg
-            startgg_match = re.match(r"https://(www\.)?(smash|start)\.gg/(tournament/[^/]+/event/[^/]+)", event)
-            challonge_match = re.match(r"https://([^\.]*)\.?challonge\.com/([^/]+)", event)
-            tonamel_match = re.match(r"https://tonamel\.com/competition/([^/]+)", event)
+            startgg_match = re.match(self.startgg_re, event)
+            challonge_match = re.match(self.challonge_re, event)
+            tonamel_match = re.match(self.tonamel_re, event)
 
             if startgg_match is not None:
                 slug = startgg_match.groups()[-1]
                 check_event(slug)
             elif challonge_match is not None:
                 org, slug = challonge_match.groups()
-                print(org, slug)
                 if org:
                     check_challonge(slug, org=org)
                 else:
                     check_challonge(slug)
             elif tonamel_match is not None:
-                print('tonamel!')
-                check_tonamel(tonamel_match.group(1))
+                slug = tonamel_match.group(1)
+                check_tonamel(slug)
 
         except Exception as ex:
             print(ex)

--- a/generar/getsets.py
+++ b/generar/getsets.py
@@ -282,7 +282,6 @@ def challonge_data(slug, org=None) :
     if org:
         slug = f'{org}-{slug}'
     url = "https://api.challonge.com/v1/tournaments/"+slug+".json?api_key="+challonge_key+"&include_participants=1"
-    print(url)
     response = requests.get(url, headers=headers)
     datos = json.loads(response.content)
     if "tournament" in datos :

--- a/generar/getsets.py
+++ b/generar/getsets.py
@@ -6,7 +6,7 @@ path = os.path.abspath(os.path.join(path, os.pardir))
 
 # Cosas de smash gg
 f = open(os.path.join(path, "smashgg.apikey"), "r")
-authToken = f.read()
+authToken = f.read().strip()
 f.close()
 apiVersion = 'alpha'
 url = 'https://api.smash.gg/gql/' + apiVersion
@@ -16,12 +16,12 @@ headers = {'Content-Type': 'application/json',
 
 # Cosas de challonge
 f = open(os.path.join(path, "challonge.apikey"), "r")
-challonge_key = f.read()
+challonge_key = f.read().strip()
 f.close()
 
 # Cosas de tonamel
 f = open(os.path.join(path, "tonamel.apikey"), "r")
-tonamel_credentials = f.read()
+tonamel_credentials = f.read().strip()
 f.close()
 tonamel_token = None
 
@@ -43,9 +43,10 @@ def check_event(slug) :
     else :
         return False
 
-def check_challonge(slug) :
+def check_challonge(slug, org=None) :
     headers = { 'User-Agent': 'Top8er' }
-    
+    if org is not None:
+        slug = org+"-"+slug
     url = "https://api.challonge.com/v1/tournaments/"+slug+".json?api_key="+challonge_key+"&include_participants=1"
     response = requests.get(url, headers=headers)
     datos = json.loads(response.content)
@@ -259,7 +260,6 @@ def event_data(slug) :
     ttext = ""
 
     
-    
     for t in ttexts  :
         if len(ttext) + len(t) < 50 :
             ttext += t
@@ -277,9 +277,10 @@ def event_data(slug) :
         }
     return datos
 
-def challonge_data(slug) :
+def challonge_data(slug, org=None) :
     headers = { 'User-Agent': 'Top8er' }
-
+    if org:
+        slug = f'{org}-{slug}'
     url = "https://api.challonge.com/v1/tournaments/"+slug+".json?api_key="+challonge_key+"&include_participants=1"
     print(url)
     response = requests.get(url, headers=headers)

--- a/templates/index.html
+++ b/templates/index.html
@@ -957,7 +957,7 @@
             {{ form2.event }}
             <p>
 			   start.gg links <strong>MUST have this format:</strong> https://start.gg/tournament/.../event/...<br>
-               challonge links <strong>MUST have this format:</strong> https://challonge.com/.../...<br>
+               challonge links <strong>MUST have this format:</strong> https://challonge.com/.../... or https://COMMUNITY.challonge.com/.../...<br> 
 			   tonamel links <strong>MUST have this format:</strong> https://tonamel.com/competition/...
 			</p>
         </div>

--- a/utils.py
+++ b/utils.py
@@ -133,21 +133,21 @@ def hestia(request, game, FormClass,
 
         if v2 :
             event = request.POST["event"]
-            patterns = [
-                    # start gg
-                    ("https://[www\.][smash]|[start].gg/tournament/[^/]+/event/[^/]+",
-                     "tournament/[^/]+/event/[^/]+",
-                     event_data, 0),
-                     # challonge
-                    ("https://challonge.com/[^/]+", ".com/[^/]+", challonge_data, 5),
-                    # tonamel
-                    ("https://tonamel.com/competition/[^/]+", ".com/competition/[^/]+", tonamel_data, 17),
-                    ]
-            for pattern, slug_pattern, data_function, offset in patterns:
-                if re.search(pattern, event):
-                    match = re.search(slug_pattern, event)
-                    slug = match[0][offset:]
-                    datos = data_function(slug)
+             # start gg
+            startgg_match = re.match(r"https://(www\.)?(smash|start)\.gg/(tournament/[^/]+/event/[^/]+)", event)
+            if startgg_match is not None:
+                slug = startgg_match.groups()[-1]
+                datos = event_data(slug)
+            # challonge
+            challonge_match = re.match(r"https://([^\.]*)\.?challonge\.com/([^/]+)", event)
+            if challonge_match is not None:
+                org, slug = challonge_match.groups()
+                datos = challonge_data(slug, org=org)
+            # tonamel
+            tonamel_match = re.match(r"https://tonamel\.com/competition/([^/]+)", event)
+            if tonamel_match is not None:
+                datos = tonamel_data(tonamel_match.group(1))
+
             init_data = {}
 
             init_data["ttext"] = datos["toptext"]

--- a/utils.py
+++ b/utils.py
@@ -133,18 +133,16 @@ def hestia(request, game, FormClass,
 
         if v2 :
             event = request.POST["event"]
-             # start gg
-            startgg_match = re.match(r"https://(www\.)?(smash|start)\.gg/(tournament/[^/]+/event/[^/]+)", event)
+            # This is a copy of the validation code in forms.py, consider refactoring
+            startgg_match = re.match(form2.startgg_re, event)
             if startgg_match is not None:
                 slug = startgg_match.groups()[-1]
                 datos = event_data(slug)
-            # challonge
-            challonge_match = re.match(r"https://([^\.]*)\.?challonge\.com/([^/]+)", event)
+            challonge_match = re.match(form2.challonge_re, event)
             if challonge_match is not None:
                 org, slug = challonge_match.groups()
                 datos = challonge_data(slug, org=org)
-            # tonamel
-            tonamel_match = re.match(r"https://tonamel\.com/competition/([^/]+)", event)
+            tonamel_match = re.match(form2.tonamel_re, event)
             if tonamel_match is not None:
                 datos = tonamel_data(tonamel_match.group(1))
 


### PR DESCRIPTION
Previously Top8er could not import tournament results from Challonge brackets within a community subdomain, for example: https://ngpr.challonge.com/ngpr3_1

This fork changes some of the regex logic in Top8er to correctly import these tournaments using the Challonge API. In my tests I can now import tournaments from start.gg and both types of Challonge urls using this codebase (I wasn't able to test the Tonamel import functionality though, so please make sure I haven't broken that by accident)

I'm not a Django dev so I tried to change as little as possible while keeping syntax consistent across the three platforms. I know a lot of folks use Challonge subdomains for their tournaments so I hope this PR can help more potential users take advantage of this great web app :)